### PR TITLE
remove deprecated use of @each to watch arrays

### DIFF
--- a/addon/components/masonry-grid.js
+++ b/addon/components/masonry-grid.js
@@ -45,7 +45,7 @@ export default Ember.Component.extend({
     this.layoutMasonry();
   }),
 
-  layoutMasonry: Ember.observer('items.@each', function () {
+  layoutMasonry: Ember.observer('items.[]', function () {
     var _this = this;
 
     imagesLoaded(this.$(), function () {


### PR DESCRIPTION
@each throws an error in Ember 2+
